### PR TITLE
flag removed from re.sub(), support for python 2.6

### DIFF
--- a/datapackage/datapackage.py
+++ b/datapackage/datapackage.py
@@ -75,8 +75,7 @@ class DataPackage(object):
             
             # For each replacement we substitute (and ignore the case)
             for (old, new) in replacement_order:
-                format_string = re.sub(old, new, format_string,
-                                       flags=re.IGNORECASE)
+                format_string = re.sub("(?i)%s" % old, new, format_string)
 
             # Return the parser (here's a difference between date and datetime
             if field['type'] == 'datetime':


### PR DESCRIPTION
To support python 2.6, I needed to remove the flag `re.IGNORECASE` from the `re.sub()` function.

See http://stackoverflow.com/a/10570951 for details
