### PR TITLE
Fix for UTF-8 formatted datapackage.json files

### DIFF
--- a/datapackage/datapackage.py
+++ b/datapackage/datapackage.py
@@ -591,7 +591,7 @@ class DataPackage(Specification):
         descriptor = self.open_resource('datapackage.json')
 
         # Load the descriptor json contents
-        str_descriptor = descriptor.read().decode()
+        str_descriptor = descriptor.read()
         json_descriptor = json.loads(str_descriptor)
 
         # Return the descriptor json contents (as the dict json.load returns


### PR DESCRIPTION
The .decode() call was throwing errors on UTF8 files with accented characters. 

I found that removing it had no issues with importing, and fixed the bug. I've tested with the example CSV on the README file and it appears to work as expected.
