### PR TITLE
Fixes #49 - support opening resources from local paths

### DIFF
--- a/datapackage/datapackage.py
+++ b/datapackage/datapackage.py
@@ -177,12 +177,16 @@ class DataPackage(Specification):
         # use os.path.join if the path is local, otherwise use urljoin
         # -- we don't want to just use os.path.join because otherwise
         # on Windows it will try to create URLs with backslashes
-        if is_local(base):
-            resource_path = os.path.join(base, path)
-            return io.open(resource_path)
+        if is_url(path):
+            return compat.urlopen(path)
         else:
-            resource_path = compat.parse.urljoin(base, path)
-            return compat.urlopen(resource_path)
+            if is_local(base):
+                resource_path = os.path.join(base, path)
+                return io.open(resource_path, 'rb')  # Read file in binary mode to mimick behavior of urlopen
+            else:
+                resource_path = compat.parse.urljoin(base, path)
+                return compat.urlopen(resource_path)  # Do not use os.path.join here since url separators do not change with platform
+
 
     @property
     def name(self):

--- a/datapackage/util.py
+++ b/datapackage/util.py
@@ -174,7 +174,7 @@ def parse_version(version):
     try:
         minor = int(minor)
     except ValueError:
-        raise ValueError("minor version is not an integer: {0}".format(major))
+        raise ValueError("minor version is not an integer: {0}".format(minor))
 
     # check for metadata
     if "+" in patch:

--- a/tests/test.dpkg_local/country-codes.csv
+++ b/tests/test.dpkg_local/country-codes.csv
@@ -1,0 +1,5 @@
+name,name_fr,ISO3166-1-Alpha-2,ISO3166-1-Alpha-3,ISO3166-1-numeric,ITU,MARC,WMO,DS,Dial,FIFA,FIPS,GAUL,IOC,currency_alphabetic_code,currency_country_name,currency_minor_unit,currency_name,currency_numeric_code,is_independent
+Afghanistan,Afghanistan,AF,AFG,004,AFG,af,AF,AFG,93,AFG,AF,1,AFG,AFN,AFGHANISTAN,2,Afghani,971,Yes
+Albania,Albanie,AL,ALB,008,ALB,aa,AB,AL,355,ALB,AL,3,ALB,ALL,ALBANIA,2,Lek,008,Yes
+Algeria,Algérie,DZ,DZA,012,ALG,ae,AL,DZ,213,ALG,AG,4,ALG,DZD,ALGERIA,2,Algerian Dinar,012,Yes
+American Samoa,Samoa Américaines,AS,ASM,016,SMA,as, ,USA,1-684,ASA,AQ,5,ASA,USD,AMERICAN SAMOA,2,US Dollar,840,Territory of US

--- a/tests/test.dpkg_local/datapackage.json
+++ b/tests/test.dpkg_local/datapackage.json
@@ -1,0 +1,130 @@
+{
+  "name": "test.dpkg_1",
+  "resources": [
+    {
+      "path": "country-codes.csv",
+      "schema": {
+        "fields": [
+          {
+            "name": "name",
+            "description": "Country's official English short name",
+            "type": "string"
+          },
+          {
+            "name": "name_fr",
+            "description": "Country's offical French short name",
+            "type": "string"
+          },
+          {
+            "name": "ISO3166-1-Alpha-2",
+            "description": "Alpha-2 codes from ISO 3166-1",
+            "type": "string"
+          },
+          {
+            "name": "ISO3166-1-Alpha-3",
+            "description": "Alpha-3 codes from ISO 3166-1 (synonymous with World Bank Codes)",
+            "type": "string"
+          },
+          {
+            "name": "ISO3166-1-numeric",
+            "description": "Numeric codes from ISO 3166-1 (synonymous with UN Statistics M49 Codes)",
+            "type": "integer"
+          },
+          {
+            "name": "ITU",
+            "description": "Codes assigned by the International Telecommunications Union",
+            "type": "string"
+          },
+          {
+            "name": "MARC",
+            "description": "MAchine-Readable Cataloging codes from the Library of Congress",
+            "type": "string"
+          },
+          {
+            "name": "WMO",
+            "description": "Country abbreviations by the World Meteorological Organization",
+            "type": "string"
+          },
+          {
+            "name": "DS",
+            "description": "Distinguishing signs of vehicles in international traffic",
+            "type": "string"
+          },
+          {
+            "name": "Dial",
+            "description": "Country code from ITU-T recommendation E.164, sometimes followed by area code",
+            "type": "string"
+          },
+          {
+            "name": "FIFA",
+            "description": "Codes assigned by the Fédération Internationale de Football Association",
+            "type": "string"
+          },
+          {
+            "name": "FIPS",
+            "description": "Codes from the U.S. standard FIPS PUB 10-4",
+            "type": "string"
+          },
+          {
+            "name": "GAUL",
+            "description": "Global Administrative Unit Layers from the Food and Agriculture Organization",
+            "type": "integer"
+          },
+          {
+            "name": "IOC",
+            "description": "Codes assigned by the International Olympics Committee",
+            "type": "string"
+          },
+          {
+            "name": "currency_alphabetic_code",
+            "description": "ISO 4217 currency alphabetic code",
+            "type": "string"
+          },
+          {
+            "name": "currency_country_name",
+            "description": "ISO 4217 country name",
+            "type": "string"
+          },
+          {
+            "name": "currency_minor_unit",
+            "description": "ISO 4217 currency number of minor units",
+            "type": "integer"
+          },
+          {
+            "name": "currency_name",
+            "description": "ISO 4217 currency name",
+            "type": "string"
+          },
+          {
+            "name": "currency_numeric_code",
+            "description": "ISO 4217 currency numeric code",
+            "type": "integer"
+          },
+          {
+            "name": "is_independent",
+            "description": "Country status, based on the CIA World Factbook",
+            "type": "string"
+          }
+        ]
+      },
+      "name": "country-codes"
+    }
+  ],
+  "license": "ODC-BY-1.0",
+  "datapackage_version": "1.0-beta.10",
+  "title": "A simple datapackage for testing",
+  "description": "A simple, bare datapackage created for testing purposes.",
+  "homepage": "http://localhost/",
+  "version": "1.0.0",
+  "sources": [
+    {
+      "name": "World Bank and OECD",
+      "web": "http://data.worldbank.org/indicator/NY.GDP.MKTP.CD"
+    }
+  ],
+  "keywords": [
+    "testing"
+  ],
+  "image": "test.jpg"
+}
+

--- a/tests/test.dpkg_url/datapackage.json
+++ b/tests/test.dpkg_url/datapackage.json
@@ -1,0 +1,132 @@
+{
+  "name": "test.dpkg_1",
+  "resources": [
+    {
+      "path": "country-codes.csv",
+      "url": "http://example.com/country-codes.csv",
+      "encoding": "utf-8",
+      "schema": {
+        "fields": [
+          {
+            "name": "name",
+            "description": "Country's official English short name",
+            "type": "string"
+          },
+          {
+            "name": "name_fr",
+            "description": "Country's offical French short name",
+            "type": "string"
+          },
+          {
+            "name": "ISO3166-1-Alpha-2",
+            "description": "Alpha-2 codes from ISO 3166-1",
+            "type": "string"
+          },
+          {
+            "name": "ISO3166-1-Alpha-3",
+            "description": "Alpha-3 codes from ISO 3166-1 (synonymous with World Bank Codes)",
+            "type": "string"
+          },
+          {
+            "name": "ISO3166-1-numeric",
+            "description": "Numeric codes from ISO 3166-1 (synonymous with UN Statistics M49 Codes)",
+            "type": "integer"
+          },
+          {
+            "name": "ITU",
+            "description": "Codes assigned by the International Telecommunications Union",
+            "type": "string"
+          },
+          {
+            "name": "MARC",
+            "description": "MAchine-Readable Cataloging codes from the Library of Congress",
+            "type": "string"
+          },
+          {
+            "name": "WMO",
+            "description": "Country abbreviations by the World Meteorological Organization",
+            "type": "string"
+          },
+          {
+            "name": "DS",
+            "description": "Distinguishing signs of vehicles in international traffic",
+            "type": "string"
+          },
+          {
+            "name": "Dial",
+            "description": "Country code from ITU-T recommendation E.164, sometimes followed by area code",
+            "type": "string"
+          },
+          {
+            "name": "FIFA",
+            "description": "Codes assigned by the Fédération Internationale de Football Association",
+            "type": "string"
+          },
+          {
+            "name": "FIPS",
+            "description": "Codes from the U.S. standard FIPS PUB 10-4",
+            "type": "string"
+          },
+          {
+            "name": "GAUL",
+            "description": "Global Administrative Unit Layers from the Food and Agriculture Organization",
+            "type": "integer"
+          },
+          {
+            "name": "IOC",
+            "description": "Codes assigned by the International Olympics Committee",
+            "type": "string"
+          },
+          {
+            "name": "currency_alphabetic_code",
+            "description": "ISO 4217 currency alphabetic code",
+            "type": "string"
+          },
+          {
+            "name": "currency_country_name",
+            "description": "ISO 4217 country name",
+            "type": "string"
+          },
+          {
+            "name": "currency_minor_unit",
+            "description": "ISO 4217 currency number of minor units",
+            "type": "integer"
+          },
+          {
+            "name": "currency_name",
+            "description": "ISO 4217 currency name",
+            "type": "string"
+          },
+          {
+            "name": "currency_numeric_code",
+            "description": "ISO 4217 currency numeric code",
+            "type": "integer"
+          },
+          {
+            "name": "is_independent",
+            "description": "Country status, based on the CIA World Factbook",
+            "type": "string"
+          }
+        ]
+      },
+      "name": "country-codes"
+    }
+  ],
+  "license": "ODC-BY-1.0",
+  "datapackage_version": "1.0-beta.10",
+  "title": "A simple datapackage for testing",
+  "description": "A simple, bare datapackage created for testing purposes.",
+  "homepage": "http://localhost/",
+  "version": "1.0.0",
+  "sources": [
+    {
+      "name": "World Bank and OECD",
+      "web": "http://data.worldbank.org/indicator/NY.GDP.MKTP.CD"
+    }
+  ],
+  "keywords": [
+    "testing"
+  ],
+  "image": "test.jpg"
+}
+

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -626,3 +626,21 @@ class TestDatapackage(object):
             name='villain', title='Movie villain')
         foreign_key = datapackage.schema.ForeignKey(fields=[villain],
                                                     reference=reference)
+
+    @mocklib.patch('datapackage.compat.urlopen')
+    def test_open_resource_url(self, mocklib_urlopen):
+        dpkg = datapackage.DataPackage("tests/test.dpkg_url/")
+        list(dpkg.data) # Force the iteration over the iterable returned from data property.
+        mocklib_urlopen.assert_called_once_with('http://example.com/country-codes.csv')
+
+    def test_open_resource_local(self):
+        dpkg = datapackage.DataPackage("tests/test.dpkg_local/")
+        with mocklib.patch('io.open') as mocklib_open:
+            list(dpkg.data) # Force the iteration over the iterable returned from data property.
+            mocklib_open.assert_called_once()
+
+    def test_open_resource_encoding(self):
+        dpkg = datapackage.DataPackage("tests/test.dpkg_local/")
+        rows = list(dpkg.data) # Force the iteration over the iterable returned from data property.
+        # And make sure we were able to get some utf-8 data out of thereget
+        assert 'Alg\xe9rie' == rows[2]['name_fr']


### PR DESCRIPTION
I tried to clean it up, but realize this PR is still a little dirty with the beginning of the fix for the typecasting (#48) -- specifically the country-codes CSV file snippet.